### PR TITLE
Fix for MySQL version check subroutine (issue #7)

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -463,28 +463,30 @@ sub mysql_version_ge {
 # Checks for 32-bit boxes with more than 2GB of RAM
 my ($arch);
 sub check_architecture {
-	# Checking MySQL compiled version
-	if ($myvar{'version_compile_machine'} =~ /x86_64/) {
-		# We have 64-bit version of MySQL
+	# We assume that 32-bit version is used by default
+	$arch = 32;
+
+	# If version_compile_machine ends with 64
+	# then we have 64-bit MySQL on non-Windows OS
+	if ($myvar{'version_compile_machine'} =~ /64$/) {
 		$arch = 64;
 		goodprint "Operating on 64-bit version of MySQL\n";
-	} elsif ($myvar{'version_compile_machine'} =~ /i*86/) {
-		# We have 32-bit version of MySQL
-		$arch = 32;
-		
-		# Check for available memory and suggest switching to
-		# 64-bit version of mysql
-		if ($physical_memory > 2147483648) {
-                        badprint "Switch to 64-bit version of MySQL\n";
-                        badprint "MySQL cannot currently use all of your RAM\n";
-                } else {
-                        goodprint "Operating on 32-bit version of MySQL with less than 2GB RAM\n";
-                }
-	} else {
-		# Unknown version or missing compile string
-		$arch = 0;
-		badprint "Operating on unknown version of MySQL\n"
+	} elsif ($myvar{'version_compile_os'} =~ /64$/) {
+		# We have 64-bit version of MySQL on 64-bit Windows OS
+		$arch = 64;
+		goodprint "Operating on 64-bit version of MySQL\n";    
 	}
+
+	# Check for available memory and suggest switching to
+        # 64-bit version of mysql
+	if ($arch == 32) {
+	        if ($physical_memory > 2147483648) {
+        	        badprint "Switch to 64-bit version of MySQL\n";
+                	badprint "MySQL cannot currently use all of your RAM\n";
+	        } else {
+        	        goodprint "Operating on 32-bit version of MySQL with less than 2GB RAM\n";
+        	}
+	} # end-if-32-bit-arch-check
 } #end-sub-check_architecture
 
 # Start up a ton of storage engine counts/statistics


### PR DESCRIPTION
Adopting scop's idea for more reliable version recognition, both for local and remote servers.

Version check should work as follows:
- assuming that 32-bit version of MySQL is used by default
- check if 'version_compile_machine' ends with string '64' - if yes, then change version to 64-bit (on non-Windows OS)
- check if 'version_compile_os' ends with string '64' - if yes, then change version to 64-bit (on Windows OS)
- in all other cases MySQL version should be 32-bit
