### PR TITLE
improve "$arch" variable usage

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -763,7 +763,7 @@ sub mysql_stats {
 
 	# Memory usage
 	infoprint "Total buffers: ".hr_bytes($mycalc{'server_buffers'})." global + ".hr_bytes($mycalc{'per_thread_buffers'})." per thread ($myvar{'max_connections'} max threads)\n";
-	if ($mycalc{'total_possible_used_memory'} > 2*1024*1024*1024 && $arch eq 32) {
+	if ($arch && $arch == 32 && $mycalc{'total_possible_used_memory'} > 2*1024*1024*1024) {
 		badprint "Allocating > 2GB RAM on 32-bit systems can cause system instability\n";
 		badprint "Maximum possible memory usage: ".hr_bytes($mycalc{'total_possible_used_memory'})." ($mycalc{'pct_physical_memory'}% of installed RAM)\n";
 	} elsif ($mycalc{'pct_physical_memory'} > 85) {


### PR DESCRIPTION
- handle the (default!) undefined case;
- really treat it as a number (cause that's the way it is defined everywhere in "check_architecture", and it is compared to a number too);
- (try to) avoid extra ops by reordering the operations.
- users will run into the undefined case whenever checking a remote server
