### PR TITLE
Don't hardcode perl path in shebang

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl -w
 # mysqltuner.pl - Version 1.3.0
 # High Performance MySQL Tuning Script
 # Copyright (C) 2006-2014 Major Hayden - major@mhtx.net


### PR DESCRIPTION
Use universal way of determining current default version of perl. Useful when perl is installed at /usr/bin/local or activated via perlbrew. See http://perlbrew.pl/Dealing-with-shebangs.html for more details.