### PR TITLE
Adding check for autoincrement keys

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -29,7 +29,7 @@
 #   Blair Christensen      Hans du Plooy        Victor Trac
 #   Everett Barnes         Tom Krouper          Gary Barrueto
 #   Simon Greenaway        Adam Stein           Isart Montane
-#   Baptiste M.
+#   Baptiste M.		   Cole Turner
 #
 # Inspired by Matthew Montgomery's tuning-primer.sh script:
 # http://forge.mysql.com/projects/view.php?id=44


### PR DESCRIPTION
I'm not familiar with Perl, but the code validates and seems to work properly. 

It uses a MySQL trick, "SELECT ~0" to get the maximum unsigned integer value. This query is untested and compatibility unknown for anything except MySQL 5.1+.

Then it cycles through the table status, comparing the current autoincrement values.
