### PR TITLE
Adding advice for innodb_buffer_pool_instances for mysql 5.6.6+ version  

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Compatibility:
 
 * MySQL 3.23, 4.0, 4.1, 5.0, 5.1 (full support)
 * MySQL 5.4 (not fully tested, partially supported)
+* MySQL 5.5 (partial support)
+* MySQL 5.6 (partial support)
 * MySQL 6.0 (partial support)
 * MariaDB 10.x (partial support)
 * Perl 5.6 or later (with [perl-doc](http://search.cpan.org/~dapm/perl-5.14.4/pod/perldoc.pod) package)
@@ -29,7 +31,7 @@ MySQL in other areas.
 Download/Installation
 --
 
-You can download the entire repository by using 'git clone' followed by the cloning URL above.  The simplest and shortest method is:
+You can download the entire repository by using 'git clone' followed by the cloning URL above. The simplest and shortest method is:
 
 	wget http://mysqltuner.pl/ -O mysqltuner.pl
 	perl mysqltuner.pl

--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1,5 +1,5 @@
 #!/usr/bin/perl -w
-# mysqltuner.pl - Version 1.4.2
+# mysqltuner.pl - Version 1.4.3
 # High Performance MySQL Tuning Script
 # Copyright (C) 2006-2014 Major Hayden - major@mhtx.net
 #
@@ -42,7 +42,7 @@ use Getopt::Long;
 use File::Basename;
 use Cwd 'abs_path';
 # Set up a few variables for use in the script
-my $tunerversion = "1.4.2";
+my $tunerversion = "1.4.3";
 my (@adjvars, @generalrec);
 
 # Set defaults
@@ -1136,8 +1136,28 @@ sub mysql_stats {
 		    badprint "InnoDB log waits: ".$mystat{'Innodb_log_waits'};
     		push(@adjvars,"innodb_log_buffer_size (>= ".hr_bytes_rnd($myvar{'innodb_log_buffer_size'}).")");
     	} else {
-    		goodprint "InnoDB log waits: ".$mystat{'Innodb_log_waits'};
+    		goodprint "InnoDB log waits: ".$mystat{'Innodb_log_waits'}."\n";
     	}
+    	if (defined($myvar{'innodb_buffer_pool_instances'})) {
+    		infoprint "MySQL version: " .$myvar{'version'}." is greater than MySQL 5.6.6(innodb_buffer_pool_instances is present)\n";
+			if ($myvar{'innodb_buffer_pool_instances'} > 64) {
+				badprint "InnoDB buffer pool instances must be lower than 64.\n";
+				push(@adjvars,"innodb_buffer_pool_instances must be lower than 64.");
+			} else {
+				goodprint "InnoDB buffer pool instances is lower than 64.\n";
+			}
+			infoprint "Buffer Pool Size: ".hr_bytes_rnd($myvar{'innodb_buffer_pool_size'})."\n";
+			infoprint "Buffer Pool Inst: $myvar{'innodb_buffer_pool_instances'}\n";
+			if ($myvar{'innodb_buffer_pool_size'} > 1024*1024*1024 
+					and (
+						($myvar{'innodb_buffer_pool_size'}/$myvar{'innodb_buffer_pool_instances'}) < 1024*1024*924
+					or  ($myvar{'innodb_buffer_pool_size'}/$myvar{'innodb_buffer_pool_instances'}) > 1024*1024*1124 ) ) {
+				badprint "InnoDB buffer pool is greater than 1Go and each InnoDB buffer pool instance must manage 900Mo to 1.1Go buffer pool size";
+				push(@adjvars,"innodb_buffer_pool_instances must be calculated with innodb_buffer_pool_size / 1Go ");
+			} else {
+				goodprint "InnoDB buffer pool instances is configurated for managing around 1Go Buffer pool size.";
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Hi,

5.6.6 introduces innodb_buffer_pool_instances (thread).
Advice for documentation:
---------------------------------
https://dev.mysql.com/doc/refman/5.6/en/innodb-parameters.html#sysvar_innodb_buffer_pool_instances
innodb_buffer_pool_instances <=64
innodb_buffer_pool_instances = innodb_buffer_pool_size / 1Go.

Best regards,
Jean-Marie

