### PR TITLE
Detect CYGWIN

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -777,7 +777,7 @@ sub os_setup {
         }
     }
     else {
-        if ( $os =~ /Linux/ ) {
+        if ( $os =~ /Linux|CYGWIN/ ) {
             $physical_memory =
               `grep -i memtotal: /proc/meminfo | awk '{print \$2}'`
               or memerror;


### PR DESCRIPTION
Simple change to detect CYGWIN.

```
$ uname
CYGWIN_NT-6.1
```

Note: cygwin users must install the `procps` package to enable support for `/proc/...`.