### PR TITLE
Fixed asking for username/password when it's already passed.

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -598,7 +598,7 @@ sub mysql_setup {
             # Login went just fine
             $mysqllogin = " $remotestring ";
 
-       # Did this go well because of a .my.cnf file or is there no password set?
+			# Did this go well because of a .my.cnf file or is there no password set?
             my $userpath = `printenv HOME`;
             if ( length($userpath) > 0 ) {
                 chomp($userpath);
@@ -615,13 +615,27 @@ sub mysql_setup {
                 badprint "Attempted to use login credentials, but they were invalid";
                 exit 1;
             }
-
-            print STDERR "Please enter your MySQL administrative login: ";
-            my $name = <>;
-            print STDERR "Please enter your MySQL administrative password: ";
-            system("stty -echo >$devnull 2>&1");
-            my $password = <>;
-            system("stty echo >$devnull 2>&1");
+			my ($name, $password);
+			# If --user is defined no need to ask for username
+			if( $opt{user} ne 0 )
+			{
+				$name = $opt{user};
+			}
+			else{
+				print STDERR "Please enter your MySQL administrative login: ";
+				$name = <STDIN>;
+			}
+			# If --pass is defined no need to ask for password
+			if( $opt{pass} ne 0 )
+			{
+				$password = $opt{pass};
+			}
+			else{
+				print STDERR "Please enter your MySQL administrative password: ";
+				system("stty -echo >$devnull 2>&1");
+				$password = <STDIN>;
+				system("stty echo >$devnull 2>&1");
+			}
             chomp($password);
             chomp($name);
             $mysqllogin = "-u $name";

--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -492,9 +492,9 @@ sub mysql_setup {
         }
         infoprint "Performing tests on $opt{host}:$opt{port}";
         $remotestring = " -h $opt{host} -P $opt{port}";
-		if (($opt{host} ne "127.0.0.1") && ($opt{host} ne "localhost")) {
-        	$doremote     = 1;
-		}
+        if (($opt{host} ne "127.0.0.1") && ($opt{host} ne "localhost")) {
+            $doremote     = 1;
+        }
     }
 
     # Did we already get a username and password passed on the command line?
@@ -598,7 +598,7 @@ sub mysql_setup {
             # Login went just fine
             $mysqllogin = " $remotestring ";
 
-			# Did this go well because of a .my.cnf file or is there no password set?
+            # Did this go well because of a .my.cnf file or is there no password set?
             my $userpath = `printenv HOME`;
             if ( length($userpath) > 0 ) {
                 chomp($userpath);
@@ -615,27 +615,27 @@ sub mysql_setup {
                 badprint "Attempted to use login credentials, but they were invalid";
                 exit 1;
             }
-			my ($name, $password);
-			# If --user is defined no need to ask for username
-			if( $opt{user} ne 0 )
-			{
-				$name = $opt{user};
-			}
-			else{
-				print STDERR "Please enter your MySQL administrative login: ";
-				$name = <STDIN>;
-			}
-			# If --pass is defined no need to ask for password
-			if( $opt{pass} ne 0 )
-			{
-				$password = $opt{pass};
-			}
-			else{
-				print STDERR "Please enter your MySQL administrative password: ";
-				system("stty -echo >$devnull 2>&1");
-				$password = <STDIN>;
-				system("stty echo >$devnull 2>&1");
-			}
+            my ($name, $password);
+            # If --user is defined no need to ask for username
+            if( $opt{user} ne 0 )
+            {
+                $name = $opt{user};
+            }
+            else{
+                print STDERR "Please enter your MySQL administrative login: ";
+                $name = <STDIN>;
+            }
+            # If --pass is defined no need to ask for password
+            if( $opt{pass} ne 0 )
+            {
+                $password = $opt{pass};
+            }
+            else{
+                print STDERR "Please enter your MySQL administrative password: ";
+                system("stty -echo >$devnull 2>&1");
+                $password = <STDIN>;
+                system("stty echo >$devnull 2>&1");
+            }
             chomp($password);
             chomp($name);
             $mysqllogin = "-u $name";


### PR DESCRIPTION
Fixed asking for username/password when it's already passed.
## Before
![fixinfoask before](https://cloud.githubusercontent.com/assets/8887221/13030760/88d25c8e-d2be-11e5-8919-f7de7f9d6000.PNG)

- First query --user is provied but still asked
- Third query --pass is provied but still asked

## After
![fixinfoask after](https://cloud.githubusercontent.com/assets/8887221/13030761/8e2ae246-d2be-11e5-9279-5a61c4d9615e.PNG)