### PR TITLE
TX and RX now shows value in K/M/G, rather than K/M/B

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1729,9 +1729,9 @@ sub mysql_stats {
       . " qps], "
       . hr_num( $mystat{'Connections'} )
       . " conn," . " TX: "
-      . hr_num( $mystat{'Bytes_sent'} )
+      . hr_bytes_rnd( $mystat{'Bytes_sent'} )
       . ", RX: "
-      . hr_num( $mystat{'Bytes_received'} ) . ")";
+      . hr_bytes_rnd( $mystat{'Bytes_received'} ) . ")";
     infoprint "Reads / Writes: "
       . $mycalc{'pct_reads'} . "% / "
       . $mycalc{'pct_writes'} . "%";


### PR DESCRIPTION
I was rather confused as to why TX and RX reported values in B (which I thought meant bytes).

I think those values should be represented as Kilo, Mega and Giga (K/M/G) rather than Kilo, Million, Billion, as that is not the usually suffix we use for bytes.

