### PR TITLE
Fix grammar in one of the messages

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1136,7 +1136,7 @@ sub system_recommendations {
     if ( (0.15*$physical_memory) < $omem) {
       badprint "Other user process except mysqld used more than 15% of total physical memory ". percentage($omem, $physical_memory). "% (".hr_bytes_rnd($omem). " / ".hr_bytes_rnd($physical_memory).")";
       push( @generalrec, "Consider stopping or dedicate server for additionnal process other than mysqld." );
-      push( @adjvars, "DON'T APPLY SETTINGS BECAUSE THERE IS TOO MANY PROCESSES RUNNING ON THIS SERVER. OOM KILL CAN OCCURS !" );
+      push( @adjvars, "DON'T APPLY SETTINGS BECAUSE THERE ARE TOO MANY PROCESSES RUNNING ON THIS SERVER. OOM KILL CAN OCCUR!" );
     } else {
       infoprint "Other user process except mysqld used less than 15% of total physical memory ". percentage($omem, $physical_memory). "% (".hr_bytes_rnd($omem). " / ".hr_bytes_rnd($physical_memory).")";
     }


### PR DESCRIPTION
```
DON'T APPLY SETTINGS BECAUSE THERE IS TOO MANY PROCESSES RUNNING ON THIS SERVER. OOM KILL CAN OCCURS !
```