### PR TITLE
fix mount point output for linux

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1091,11 +1091,11 @@ sub get_os_release {
 
 sub get_fs_info() {
     my @sinfo = `df -P | grep '%'`;
-    shift @sinfo;
     my @iinfo = `df -Pi| grep '%'`;
     shift @iinfo;
     map { s/.*\s(\d+)%\s+(.*)/$1\t$2/g } @sinfo;
     foreach my $info (@sinfo) {
+        next if $info =~ m{(\d+)\t/(run|dev|sys|proc)($|/)};
         if ( $info =~ /(\d+)\t(.*)/ ) {
             if ( $1 > 85 ) {
                 badprint "mount point $2 is using $1 % total space";
@@ -1109,6 +1109,7 @@ sub get_fs_info() {
 
     map { s/.*\s(\d+)%\s+(.*)/$1\t$2/g } @iinfo;
     foreach my $info (@iinfo) {
+        next if $info =~ m{(\d+)\t/(run|dev|sys|proc)($|/)};
         if ( $info =~ /(\d+)\t(.*)/ ) {
             if ( $1 > 85 ) {
                 badprint "mount point $2 is using $1 % of max allowed inodes";


### PR DESCRIPTION
In linux mount point info not show disk space on / and show many virtual fs.
It return "/" in disk space output and skip /proc, /dev and /sys entries.

Example output befor this changes - 
```
[--] Other user process except mysqld used less than 15% of total physical memory 4.33% (221M / 5G)
[--] mount point /sys/fs/cgroup is using 0 % of total space
[--] mount point /dev is using 0 % of total space
[--] mount point /dev/shm is using 0 % of total space
[--] mount point /run is using 3 % of total space
[--] mount point /run/lock is using 0 % of total space
[--] mount point /run/shm is using 0 % of total space
[--] mount point / is using 5 % of max allowed inodes
[--] mount point /sys/fs/cgroup is using 1 % of max allowed inodes
[--] mount point /dev is using 1 % of max allowed inodes
[--] mount point /dev/shm is using 1 % of max allowed inodes
[--] mount point /run is using 1 % of max allowed inodes
[--] mount point /run/lock is using 1 % of max allowed inodes
[--] mount point /run/shm is using 1 % of max allowed inodes

```

After - 
```
[--] Other user process except mysqld used less than 15% of total physical memory 4.50% (230M / 5G)
[--] mount point / is using 11 % of total space
[--] mount point / is using 5 % of max allowed inodes
```