### PR TITLE
Detect Ubuntu correctly when checking for OS Release

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1107,6 +1107,15 @@ sub get_other_process_memory {
 }
 
 sub get_os_release {
+   if( -f "/etc/lsb-release") {
+        my @info_release = get_file_contents "/etc/lsb-release";
+        remove_cr @info_release;
+        my $os_relase = $info_release[3];
+        $os_relase =~ s/.*="//;
+        $os_relase =~ s/"$//;
+        return $os_relase;
+   }
+
    if( -f "/etc/system-release") {
         my @info_release = get_file_contents "/etc/system-release";
         remove_cr @info_release;


### PR DESCRIPTION
Hello,

I am using MySQLTuner in Ubuntu and I noticed that the script is reporting `Unknown OS release`. I looked at the source code and noticed that the function `get_os_release` was not checking the correct file under Ubuntu which is `/etc/lsb-release`.

This PR adds support for checking `/etc/lsb-release`. I kept the same logic as the other checks. The regex is basically the same as with the `/etc/os-release` check so perhaps it could be improved to use less LOC.

I await your feedback :)

Thank you,
Ricardo