### PR TITLE
Improve portability when fetching process memory 

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1088,15 +1088,15 @@ sub is_open_port {
 
 sub get_process_memory {
     my $pid = shift;
-    return 0 unless -f "/proc/$pid/status";
-    my @pdata = grep { /RSS:/ } get_file_contents "/proc/$pid/status";
-    map { s/.*RSS:\s*(\d+)\s*kB\s*$/$1*1024/ge } @pdata;
-    return $pdata[0];
+    my @mem = `ps -p $pid -o rss`;
+    return 0 if scalar @mem != 2;
+    return $mem[1]*1024;
 }
 
 sub get_other_process_memory {
-    my @procs = `ps -eo pid,cmd`;
+    my @procs = `ps -eaxo pid,command`;
     map {
+        s/.*PID.*//;
         s/.*mysqld.*//;
         s/.*\[.*\].*//;
         s/^\s+$//g;


### PR DESCRIPTION
MySQLTuner uses the /proc filesystem for fetching the memory usage of other processes. /proc isn't available on all platforms.

This PR alters the `get_process_memory` function to use ps, and adjusts the arguments to ps in `get_other_process_memory` to work cross platform.

Tested on OpenBSD 5.9 and Debian 7.10

_Note - the two functions could be merged and make a single call to PS to get both the process list and the RSS of each process - however, I've kept the original structure of the code to keep the diff small_