### PR TITLE
Avoid bad syntax error message

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1094,7 +1094,7 @@ sub get_process_memory {
 }
 
 sub get_other_process_memory {
-    my @procs = `ps -eaxo pid,command`;
+    my @procs = `ps eaxo pid,command`;
     map {
         s/.*PID.*//;
         s/.*mysqld.*//;


### PR DESCRIPTION
Error below when executing the script on RHEL6/OL6:
Warning: bad syntax, perhaps a bogus '-'? See /usr/share/doc/procps-3.2.8/FAQ