### PR TITLE
Avoid deprecated message from perl

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -3240,7 +3240,8 @@ sub mariadb_galera {
         {
             goodprint "Galera Cluster address is defined: "
               . $myvar{'wsrep_cluster_address'};
-            my $nbNodes = scalar( split /,/, $myvar{'wsrep_cluster_address'} );
+            my @NodesTmp = split /,/, $myvar{'wsrep_cluster_address'};
+            my $nbNodes = @NodesTmp;
             infoprint "There are $nbNodes nodes in wsrep_cluster_address";
             my $nbNodesSize = trim( $mystat{'wsrep_cluster_size'} );
             if ( $nbNodesSize == 3 or $nbNodesSize == 5 ) {


### PR DESCRIPTION
Use of implicit split to @_ is deprecated at /tmp/mysqltuner.pl line 3243 (#1)
    (D deprecated, W syntax) It makes a lot of work for the compiler when you
    clobber a subroutine's argument list, so it's better if you assign the results
    of a split() explicitly to an array (or list).