### PR TITLE
Don't exit after positive latest version check

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -590,7 +590,7 @@ sub compare_tuner_version {
         return;
     }
     goodprint "You have the latest version of MySQLTuner($tunerversion)";
-    exit 0;
+    return;
 }
 
 # Checks to see if a MySQL login is possible


### PR DESCRIPTION
I'm proposing to revert commit d14809363477843903b074d1ef838838342494a. It introduced simple change that broke my shell scripts which logged all mysqltuner.pl output from several remote servers. Suddenly, they stopped gathering data when latest version of the script was used although it seemed to be running without error. I do not understand the rationale behind d148093 - what was wrong with original code? Also the change was inconsistent with script behaviour when script is not in its latest version.