### PR TITLE
Add new passwords and remove duplicates in basic_passwords.txt

### DIFF
--- a/basic_passwords.txt
+++ b/basic_passwords.txt
@@ -386,7 +386,6 @@ little
 biteme
 hardcore
 white
-0
 redwings
 66
 enter
@@ -600,8 +599,6 @@ success
 albert
 mysql
 MySQL
-Mysql
-Dba
 dba
 mypass
 MyNewPass

--- a/basic_passwords.txt
+++ b/basic_passwords.txt
@@ -603,3 +603,13 @@ MySQL
 Mysql
 Dba
 dba
+mypass
+MyNewPass
+some_pass
+admin_pass
+obscure
+password
+new_password
+new_password1
+new_password2
+root-password


### PR DESCRIPTION
Some passwords found in MySQL online documentation have been added. This includes for example passwords in MySQL create user manual (http://dev.mysql.com/doc/refman/5.7/en/create-user.html), which is often top search result for "create MySQL user". Administrators, which used the manual and forgot to update such "documented" passwords, could benefit from identification of these users.

Duplicate "0" and other passwords covered with case changes in password tests have been removed.