### PR TITLE
Fixed password option in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@ perl mysqltuner.pl
 
 <p><strong>Usage:</strong> Minimal usage remotely</p>
 
-<pre><code>perl mysqltuner.pl --host targetDNS_IP --user admin_user --password admin_password
+<pre><code>perl mysqltuner.pl --host targetDNS_IP --user admin_user --pass admin_password
 </code></pre>
 
 <p><strong>Usage:</strong> Enable maximum output information around MySQL/MariaDb without debugging </p>


### PR DESCRIPTION
Banged my head against a wall trying to figure out why mysqltuner wasn't working. Turns out, the `password` option is actually called `pass`.