### PR TITLE
Use single quotes around password

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -873,7 +873,7 @@ sub mysql_setup {
             $mysqllogin = "-u $name";
 
             if ( length($password) > 0 ) {
-                $mysqllogin .= " -p\"$password\"";
+                $mysqllogin .= " -p'$password'";
             }
             $mysqllogin .= $remotestring;
             my $loginstatus = `$mysqladmincmd ping $mysqllogin 2>&1`;


### PR DESCRIPTION
Password may contain characters, like `$` and `!`, that may be interpreted by
the shell. Prevent it to happen by using single quotes.