### PR TITLE
Fix in log file recommandations

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1161,15 +1161,23 @@ sub log_file_recommandations {
   
   infoprint scalar(@lastStarts). " start(s) detected in $myvar{'log_error'}";
   my $nStart=0;
-  for my $startd (reverse @lastStarts[-10..-1]) {
+ my $nEnd = 10;
+  if (scalar(@lastStarts) < $nEnd) {
+    $nEnd = scalar(@lastStarts);
+  }
+  for my $startd (reverse @lastStarts[-$nEnd..-1]) {
     $nStart++;
     infoprint "$nStart) $startd";
   }
   infoprint scalar(@lastShutdowns). " shutdown(s) detected in $myvar{'log_error'}";
-  my $nShut=0;
-  for my $shutd (reverse @lastShutdowns[-10..-1]) {
-    $nShut++;
-    infoprint "$nShut) $shutd";
+  $nStart=0;
+  $nEnd=10;
+  if (scalar(@lastShutdowns) < $nEnd) {
+    $nEnd = scalar(@lastShutdowns);
+  }
+  for my $shutd (reverse @lastShutdowns[-$nEnd..-1]) {
+    $nStart++;
+    infoprint "$nStart) $shutd";
   }
 	#exit 0;
 }

--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1106,79 +1106,79 @@ sub get_basic_passwords {
 sub log_file_recommandations {
     subheaderprint "Log file Recommendations";
 	infoprint "Log file: " . $myvar{'log_error'}. "(".hr_bytes_rnd((stat $myvar{'log_error'})[7]).")";
-	if (-f "$myvar{'log_error'}") {
+	if ( -f "$myvar{'log_error'}" ) {
 		goodprint "Log file $myvar{'log_error'} exists";
 	} else {
 		badprint "Log file $myvar{'log_error'} doesn't exist";
 	}
-  if (-r "$myvar{'log_error'}") {
-    goodprint "Log file $myvar{'log_error'} is readable.";
-  } else {
-    badprint "Log file $myvar{'log_error'} isn't readable.";
-    return;
-  }
-	if ( (stat $myvar{'log_error'})[7] > 0) {
+    if ( -r "$myvar{'log_error'}" ) {
+        goodprint "Log file $myvar{'log_error'} is readable.";
+    } else {
+        badprint "Log file $myvar{'log_error'} isn't readable.";
+        return;
+    }
+	if ( (stat $myvar{'log_error'})[7] > 0 ) {
 		goodprint "Log file $myvar{'log_error'} is not empty";
 	} else {
 		badprint "Log file $myvar{'log_error'} is empty";
 	}
 	
-	if ( (stat $myvar{'log_error'})[7] < 32*1024*1024) {
+	if ( (stat $myvar{'log_error'})[7] < 32*1024*1024 ) {
 		goodprint "Log file $myvar{'log_error'} is smaller than 32 Mb";
 	} else {
 		badprint "Log file $myvar{'log_error'} is bigger than 32 Mb";
-		push( @generalrec,
-        $myvar{'log_error'} ."is > 32Mb, you should analyze why or implement a rotation log strategy such as logrotate!" );
+		push @generalrec,
+        $myvar{'log_error'} ."is > 32Mb, you should analyze why or implement a rotation log strategy such as logrotate!" ;
 	}
 	
-  my @log_content=get_file_contents($myvar{'log_error'});
-
-  my $numLi=0;
-  my $nbWarnLog=0;
-  my $nbErrLog=0;
-  my @lastShutdowns;
-  my @lastStarts;
-  foreach my $logLi(@log_content) {
-    $numLi++;
-    debugprint "$numLi: $logLi" if $logLi =~ /warning|error/i;
-    $nbErrLog++ if $logLi =~ /error/i;
-    $nbWarnLog++ if $logLi =~ /warning/i;
-    push @lastShutdowns, $logLi if $logLi =~ /Shutdown complete/ and $logLi !~ /Innodb/i;
-    push @lastStarts, $logLi if $logLi =~ /ready for connections/;
-  }
-  if ($nbWarnLog > 0) {
-    badprint "$myvar{'log_error'} contains $nbWarnLog warning(s).";
-    push( @generalrec, "Control warning line(s) into $myvar{'log_error'} file");
-  } else {
-    goodprint "$myvar{'log_error'} doesn't contain any warning.";
-  }
-  if ($nbErrLog > 0) {
-    badprint "$myvar{'log_error'} contains $nbErrLog error(s).";
-    push( @generalrec, "Control error line(s) into $myvar{'log_error'} file");
-  } else {
-    goodprint "$myvar{'log_error'} doesn't contain any error.";
-  }
-  
-  infoprint scalar(@lastStarts). " start(s) detected in $myvar{'log_error'}";
-  my $nStart=0;
- my $nEnd = 10;
-  if (scalar(@lastStarts) < $nEnd) {
-    $nEnd = scalar(@lastStarts);
-  }
-  for my $startd (reverse @lastStarts[-$nEnd..-1]) {
-    $nStart++;
-    infoprint "$nStart) $startd";
-  }
-  infoprint scalar(@lastShutdowns). " shutdown(s) detected in $myvar{'log_error'}";
-  $nStart=0;
-  $nEnd=10;
-  if (scalar(@lastShutdowns) < $nEnd) {
-    $nEnd = scalar(@lastShutdowns);
-  }
-  for my $shutd (reverse @lastShutdowns[-$nEnd..-1]) {
-    $nStart++;
-    infoprint "$nStart) $shutd";
-  }
+    my @log_content = get_file_contents($myvar{'log_error'});
+    
+    my $numLi = 0;
+    my $nbWarnLog = 0;
+    my $nbErrLog = 0;
+    my @lastShutdowns;
+    my @lastStarts;
+    foreach my $logLi ( @log_content ) {
+      $numLi++;
+      debugprint "$numLi: $logLi" if $logLi =~ /warning|error/i;
+      $nbErrLog++ if $logLi =~ /error/i;
+      $nbWarnLog++ if $logLi =~ /warning/i;
+      push @lastShutdowns, $logLi if $logLi =~ /Shutdown complete/ and $logLi !~ /Innodb/i;
+      push @lastStarts, $logLi if $logLi =~ /ready for connections/;
+    }
+    if ( $nbWarnLog > 0 ) {
+      badprint "$myvar{'log_error'} contains $nbWarnLog warning(s).";
+      push @generalrec, "Control warning line(s) into $myvar{'log_error'} file";
+    } else {
+      goodprint "$myvar{'log_error'} doesn't contain any warning.";
+    }
+    if ( $nbErrLog > 0 ) {
+      badprint "$myvar{'log_error'} contains $nbErrLog error(s).";
+      push @generalrec, "Control error line(s) into $myvar{'log_error'} file";
+    } else {
+      goodprint "$myvar{'log_error'} doesn't contain any error.";
+    }
+    
+    infoprint scalar @lastStarts . " start(s) detected in $myvar{'log_error'}";
+    my $nStart = 0;
+    my $nEnd = 10;
+    if ( scalar @lastStarts < $nEnd ) {
+        $nEnd = scalar @lastStarts;
+    }
+    for my $startd ( reverse @lastStarts[-$nEnd..-1] ) {
+        $nStart++;
+        infoprint "$nStart) $startd";
+    }
+    infoprint scalar @lastShutdowns . " shutdown(s) detected in $myvar{'log_error'}";
+    $nStart=0;
+    $nEnd=10;
+    if ( scalar @lastShutdowns < $nEnd ) {
+      $nEnd = scalar @lastShutdowns;
+    }
+    for my $shutd ( reverse @lastShutdowns[-$nEnd..-1] ) {
+      $nStart++;
+      infoprint "$nStart) $shutd";
+    }
 	#exit 0;
 }
 


### PR DESCRIPTION
Hello!

Log file recommendations output befor fix - 
```
[OK] Log file /var/lib/mysql/bigfura.ru.err is smaller than 32 Mb
[!!] /var/lib/mysql/bigfura.ru.err contains 1092 warning(s).
[!!] /var/lib/mysql/bigfura.ru.err contains 144 error(s).
[--] 5 start(s) detected in /var/lib/mysql/bigfura.ru.err
[--] 1) 161025 10:28:59 [Note] /usr/libexec/mysqld: ready for connections.
[--] 2) 161024 10:01:05 [Note] /usr/libexec/mysqld: ready for connections.
[--] 3) 161006 18:54:40 [Note] /usr/libexec/mysqld: ready for connections.
[--] 4) 161006 18:54:35 [Note] /usr/libexec/mysqld: ready for connections.
[--] 5) 110719 23:18:37 [Note] /usr/libexec/mysqld: ready for connections.
Use of uninitialized value in concatenation (.) or string at mysqltuner.pl line
	1166 (#1)
    (W uninitialized) An undefined value was used as if it were already
    defined.  It was interpreted as a "" or a 0, but maybe it was a mistake.
    To suppress this warning assign a defined value to your variables.
    
    To help you figure out what was undefined, perl tells you what operation
    you used the undefined value in.  Note, however, that perl optimizes your
    program and the operation displayed in the warning may not necessarily
    appear literally in your program.  For example, "that $foo" is
    usually optimized into "that " . $foo, and the warning will refer to
    the concatenation (.) operator, even though there is no . in your
    program.
    
[--] 6) 
[--] 7) 
[--] 8) 
[--] 9) 
[--] 10) 
[--] 3 shutdown(s) detected in /var/lib/mysql/bigfura.ru.err
[--] 1) 161025 10:28:56 [Note] /usr/libexec/mysqld: Shutdown complete
[--] 2) 161006 18:54:36 [Note] /usr/libexec/mysqld: Shutdown complete
[--] 3) 110719 23:23:14 [Note] /usr/libexec/mysqld: Shutdown complete
Use of uninitialized value in concatenation (.) or string at mysqltuner.pl line
	1172 (#1)
[--] 4) 
[--] 5) 
[--] 6) 
[--] 7) 
[--] 8) 
[--] 9) 
[--] 10) 
 
```

after fix - 
```
[OK] Log file /var/lib/mysql/bigfura.ru.err is smaller than 32 Mb
[!!] /var/lib/mysql/bigfura.ru.err contains 1092 warning(s).
[!!] /var/lib/mysql/bigfura.ru.err contains 144 error(s).
[--] 5 start(s) detected in /var/lib/mysql/bigfura.ru.err
[--] 1) 161025 10:28:59 [Note] /usr/libexec/mysqld: ready for connections.
[--] 2) 161024 10:01:05 [Note] /usr/libexec/mysqld: ready for connections.
[--] 3) 161006 18:54:40 [Note] /usr/libexec/mysqld: ready for connections.
[--] 4) 161006 18:54:35 [Note] /usr/libexec/mysqld: ready for connections.
[--] 5) 110719 23:18:37 [Note] /usr/libexec/mysqld: ready for connections.
[--] 3 shutdown(s) detected in /var/lib/mysql/bigfura.ru.err
[--] 1) 161025 10:28:56 [Note] /usr/libexec/mysqld: Shutdown complete
[--] 2) 161006 18:54:36 [Note] /usr/libexec/mysqld: Shutdown complete
[--] 3) 110719 23:23:14 [Note] /usr/libexec/mysqld: Shutdown complete
```