### PR TITLE
fix check innodb_file_per_table with skip-innodb

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1991,7 +1991,9 @@ sub check_storage_engines {
             $result{'Engine'}{$engine}{'Index Size'}   = $isize;
         }
         my $not_innodb = '';
-        if ( $result{'Variables'}{'innodb_file_per_table'} eq 'OFF' ) {
+        if ( not defined $result{'Variables'}{'innodb_file_per_table'} ) {
+            $not_innodb = "AND NOT ENGINE='InnoDB'";
+        } elsif ( $result{'Variables'}{'innodb_file_per_table'} eq 'OFF' ) {
             $not_innodb = "AND NOT ENGINE='InnoDB'";
         }
         $result{'Tables'}{'Fragmented tables'} =


### PR DESCRIPTION
Hello!

Reproduced this problem on debian 7 with mysql 5.5.43 and **skip-innodb** in my.cnf.
It have not in result{varibables} key  innodb_file_per_table (only have_innodb and ignore_builtin_innodb).
Befor fix - 
```
-------- Storage Engine Statistics -----------------------------------------------------------------
[--] Status: +ARCHIVE +BLACKHOLE +CSV -FEDERATED -InnoDB +MEMORY +MRG_MYISAM +MyISAM +PERFORMANCE_SCHEMA 
Use of uninitialized value in string eq at - line 1994 (#1)
    (W uninitialized) An undefined value was used as if it were already
    defined.  It was interpreted as a "" or a 0, but maybe it was a mistake.
    To suppress this warning assign a defined value to your variables.
    
    To help you figure out what was undefined, perl will try to tell you the
    name of the variable (if any) that was undefined. In some cases it cannot
    do this, so it also tells you what operation you used the undefined value
    in.  Note, however, that perl optimizes your program and the operation
    displayed in the warning may not necessarily appear literally in your
    program.  For example, "that $foo" is usually optimized into "that "
    . $foo, and the warning will refer to the concatenation (.) operator,
    even though there is no . in your program.
    
[--] Data in MyISAM tables: 1G (Tables: 523)
[!!] Total fragmented tables: 1
 
```

After fix - 
```
-------- Storage Engine Statistics -----------------------------------------------------------------
[--] Status: +ARCHIVE +BLACKHOLE +CSV -FEDERATED -InnoDB +MEMORY +MRG_MYISAM +MyISAM +PERFORMANCE_SCHEMA 
[--] Data in MyISAM tables: 1G (Tables: 523)
[!!] Total fragmented tables: 1
 
```
