### PR TITLE
Allow to connect via socket with not default port

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -685,15 +685,15 @@ sub mysql_setup {
 
     debugprint "MySQL Client: $mysqlcmd";
 
+    $opt{port} = ( $opt{port} eq 0 ) ? 3306 : $opt{port};
     # Are we being asked to connect via a socket?
     if ( $opt{socket} ne 0 ) {
-        $remotestring = " -S $opt{socket}";
+        $remotestring = " -S $opt{socket} -P $opt{port}";
     }
 
     # Are we being asked to connect to a remote server?
     if ( $opt{host} ne 0 ) {
         chomp( $opt{host} );
-        $opt{port} = ( $opt{port} eq 0 ) ? 3306 : $opt{port};
 
 # If we're doing a remote connection, but forcemem wasn't specified, we need to exit
         if (   $opt{'forcemem'} eq 0


### PR DESCRIPTION
Seems like it is necessary to specify the port when you have 2 instances runing and you want to connect via socket.