### PR TITLE
Fix Argument "NULL" isn't numeric

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -302,6 +302,9 @@ sub infoprinthcmd {
 # Calculates the parameter passed in bytes, then rounds it to one decimal place
 sub hr_bytes {
     my $num = shift;
+    return "0B" unless  defined($num) ;
+    return "0B" if $num eq "NULL" ;
+    
     if ( $num >= ( 1024**3 ) ) {    #GB
         return sprintf( "%.1f", ( $num / ( 1024**3 ) ) ) . "G";
     }


### PR DESCRIPTION
Argument "NULL" isn't numeric in numeric ge (>=) at ./mysqltuner.pl line 305 (#1)
    (W numeric) The indicated string was fed as an argument to an operator
    that expected a numeric value instead.  If you're fortunate the message
    will identify which operator was so unfortunate.