### PR TITLE
Do not test skip_name_resolve if skip_networking is ON

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -2769,7 +2769,11 @@ sub mysql_stats {
     }
 
     # name resolution
-    if ( not defined( $result{'Variables'}{'skip_name_resolve'} ) ) {
+    if ( defined( $result{'Variables'}{'skip_networking'} ) && $result{'Variables'}{'skip_networking'} eq 'ON' ) {
+        infoprint
+"Skipped name resolution test due to skip_networking=ON in system variables.";
+    }
+    elsif ( not defined( $result{'Variables'}{'skip_name_resolve'} ) ) {
         infoprint
 "Skipped name resolution test due to missing skip_name_resolve in system variables.";
     }


### PR DESCRIPTION
MySQL name resolution only applies to TCP/IP connections ( see lines 504 and 599 of mysql-server/sql/sql_connect.cc ).  Thus there is no reason to test, or suggest, setting skip_name_resolve if skip_networking exists and is turned on.