### PR TITLE
The query cache should be disabled

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -2800,7 +2800,6 @@ sub mysql_stats {
             "Upgrade MySQL to version 4+ to utilize query caching" );
     }
     elsif ( mysql_version_ge( 5, 5 )
-        and !mysql_version_ge( 10, 1 )
         and $myvar{'query_cache_type'} eq "OFF" )
     {
         goodprint

--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -2799,19 +2799,11 @@ sub mysql_stats {
         push( @generalrec,
             "Upgrade MySQL to version 4+ to utilize query caching" );
     }
-    elsif ( mysql_version_ge( 5, 5 )
+    elsif ( $myvar{'query_cache_size'} < 1
         and $myvar{'query_cache_type'} eq "OFF" )
     {
         goodprint
 "Query cache is disabled by default due to mutex contention on multiprocessor machines.";
-    }
-    elsif ( $myvar{'query_cache_size'} < 1 ) {
-        badprint "Query cache is disabled";
-        push( @adjvars, "query_cache_size (>= 8M)" );
-    }
-    elsif ( $myvar{'query_cache_type'} eq "OFF" ) {
-        badprint "Query cache is disabled";
-        push( @adjvars, "query_cache_type (=1)" );
     }
     elsif ( $mystat{'Com_select'} == 0 ) {
         badprint
@@ -2820,6 +2812,7 @@ sub mysql_stats {
     else {
         badprint
           "Query cache may be disabled by default due to mutex contention.";
+        push( @adjvars, "query_cache_size (=0)" );
         push( @adjvars, "query_cache_type (=0)" );
         if ( $mycalc{'query_cache_efficiency'} < 20 ) {
             badprint


### PR DESCRIPTION
#302 #190 #159 

The query cache is disabled by default in 4+, not only in 5.6+.

> query_cache_size
The amount of memory allocated for caching query results. The default value is 0, which disables
the query cache. The permissible values are multiples of 1024; other values are rounded down
to the nearest multiple. Note that query_cache_size bytes of memory are allocated even if
query_cache_type is set to 0. This variable was added in MySQL 4.0.1.

http://downloads.mysql.com/docs/refman-4.1-en.pdf

https://docs.oracle.com/cd/E17952_01/mysql-5.0-en/server-system-variables.html#sysvar_query_cache_size

https://docs.oracle.com/cd/E17952_01/mysql-5.1-en/server-system-variables.html#sysvar_query_cache_size

https://docs.oracle.com/cd/E19957-01/mysql-refman-5.4/server-administration.html#sysvar_query_cache_size

https://docs.oracle.com/cd/E17952_01/mysql-5.5-en/server-system-variables.html#sysvar_query_cache_size

https://docs.oracle.com/cd/E17952_01/mysql-5.6-en/server-system-variables.html#sysvar_query_cache_size

https://docs.oracle.com/cd/E17952_01/mysql-5.7-en/server-system-variables.html#sysvar_query_cache_size

https://mariadb.com/kb/en/mariadb/server-system-variables/#query_cache_size

https://mariadb.com/kb/en/mariadb/server-system-variables/#query_cache_type