### PR TITLE
Fix version comparisons

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1902,7 +1902,7 @@ sub mysql_version_ge {
     return
          int($mysqlvermajor) > int($maj)
       || ( int($mysqlvermajor) == int($maj) && int($mysqlverminor) > int($min) )
-      || ( int($mysqlverminor) == int($min)
+      || ( int($mysqlvermajor) == int($maj) && int($mysqlverminor) == int($min)
         && int($mysqlvermicro) >= int($mic) );
 }
 
@@ -1914,7 +1914,7 @@ sub mysql_version_le {
     return
          int($mysqlvermajor) < int($maj)
       || ( int($mysqlvermajor) == int($maj) && int($mysqlverminor) < int($min) )
-      || ( int($mysqlverminor) == int($min)
+      || ( int($mysqlvermajor) == int($maj) && int($mysqlverminor) == int($min)
         && int($mysqlvermicro) <= int($mic) );
 }
 


### PR DESCRIPTION
Both the minor *and* the major versions need to match before checking the micro version.

My version (`10.0.30-MariaDB`) is reported as "unsupported", despite previously closed issues/PRs saying MariaDB 10.0 should now be supported.

Adding some debug prints to `validate_mysql_version()` revealed that `mysql_version_ge(12)` was returning true where it shouldn't.  The cause is a missing check for equal major versions on the micro version comparison -- 10.0.30 should obviously be considered less than 12.0.0, but the last clause of the OR is only checking for equal minor (0 == 0) and comparing micro (30 > 0), while ignoring major.

Before: `[!!] Currently running unsupported MySQL version 10.0.30-MariaDB`
After: `[OK] Currently running supported MySQL version 10.0.30-MariaDB`