### PR TITLE
Fix #387

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -2181,7 +2181,7 @@ sub check_storage_engines {
     }
     while ( my ( $engine, $size ) = each(%enginestats) ) {
         infoprint "Data in $engine tables: "
-          . hr_bytes_rnd($size)
+          . hr_bytes($size)
           . " (Tables: "
           . $enginecount{$engine} . ")" . "";
     }
@@ -5504,7 +5504,7 @@ sub mysql_innodb {
           . hr_bytes( $enginestats{'InnoDB'} ) . "";
         push( @adjvars,
                 "innodb_buffer_pool_size (>= "
-              . hr_bytes_rnd( $enginestats{'InnoDB'} )
+              . hr_bytes( $enginestats{'InnoDB'} )
               . ") if possible." );
     }
     if (   $mycalc{'innodb_log_size_pct'} < 20


### PR DESCRIPTION
Fix #387 

Before
```
-------- Storage Engine Statistics -----------------------------------------------------------------
[--] Data in InnoDB tables: 1G (Tables: 2)
[OK] Total fragmented tables: 0

-------- InnoDB Metrics ----------------------------------------------------------------------------
[!!] InnoDB buffer pool / data size: 128.0M/1.4G

-------- Recommendations ---------------------------------------------------------------------------
General recommendations:
    ...
Variables to adjust:
    innodb_buffer_pool_size (>= 1G) if possible.
```
After
```
-------- Storage Engine Statistics -----------------------------------------------------------------
[--] Data in InnoDB tables: 1.4G (Tables: 2)
[OK] Total fragmented tables: 0

-------- InnoDB Metrics ----------------------------------------------------------------------------
[!!] InnoDB buffer pool / data size: 128.0M/1.4G

-------- Recommendations ---------------------------------------------------------------------------
General recommendations:
    ...
Variables to adjust:
    innodb_buffer_pool_size (>= 1.4G) if possible.
```