### PR TITLE
Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,5 +44,5 @@ before_script:
   - chmod 600 .my.cnf
 
 script:
-  - perlcritic mysqltuner.pl
+  - perlcritic --exclude InputOutput::ProhibitInteractiveTest mysqltuner.pl
   - ./mysqltuner.pl --idxstat --dbstat


### PR DESCRIPTION
Now in travis we see

```
perlcritic mysqltuner.pl 
Use IO::Interactive::is_interactive() instead of -t at line 69, column 28.  See page 218 of PBP.  (Severity: 5)
Use IO::Interactive::is_interactive() instead of -t at line 203, column 28.  See page 218 of PBP.  (Severity: 5)
```

Exclude check InputOutput::ProhibitInteractiveTest.
If we want to pass test InputOutput::ProhibitInteractiveTest we need to add dependency IO::Interactive in script - This is not desirable