### PR TITLE
Minor fix undefined value

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1848,7 +1848,12 @@ sub get_replication_status {
           . " server(s).";
     }
     infoprint "Binlog format: " . $myvar{'binlog_format'};
-    infoprint "XA support enabled: " . defined($myvar{'innodb_support_xa'})?$myvar{'innodb_support_xa'}:'UNKONOWN';
+    infoprint "XA support enabled: "
+      . (
+        defined( $myvar{'innodb_support_xa'} )
+        ? $myvar{'innodb_support_xa'}
+        : 'UNKNOWN'
+      );
     infoprint "Semi synchronous replication Master: "
       . (
         defined( $myvar{'rpl_semi_sync_master_enabled'} )


### PR DESCRIPTION
Before:
```
-------- Replication Metrics -----------------------------------------------------------------------
[--] Galera Synchronous replication: NO
[--] No replication slave(s) for this server.
[--] Binlog format: STATEMENT
Use of uninitialized value in concatenation (.) or string at
	mysqltuner.pl line 233 (#1)
    (W uninitialized) An undefined value was used as if it were already
    defined.  It was interpreted as a "" or a 0, but maybe it was a mistake.
    To suppress this warning assign a defined value to your variables.
    
    To help you figure out what was undefined, perl will try to tell you the
    name of the variable (if any) that was undefined. In some cases it cannot
    do this, so it also tells you what operation you used the undefined value
    in.  Note, however, that perl optimizes your program and the operation
    displayed in the warning may not necessarily appear literally in your
    program.  For example, "that $foo" is usually optimized into "that "
    . $foo, and the warning will refer to the concatenation (.) operator,
    even though there is no . in your program.
    
[--] 
[--] Semi synchronous replication Master: Not Activated
[--] Semi synchronous replication Slave: Not Activated
[--] This is a standalone server
 ```
After
```
-------- Replication Metrics -----------------------------------------------------------------------
[--] Galera Synchronous replication: NO
[--] No replication slave(s) for this server.
[--] Binlog format: STATEMENT
[--] XA support enabled: UNKNOWN
[--] Semi synchronous replication Master: Not Activated
[--] Semi synchronous replication Slave: Not Activated
[--] This is a standalone server
```