### PR TITLE
fix defect link to mysql documentation - #408

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -5565,7 +5565,7 @@ sub mysql_innodb {
               . ") if possible, so InnoDB total log files size equals to 25% of buffer pool size."
         );
         push( @generalrec,
-"Before changing innodb_log_file_size and/or innodb_log_files_in_group read this: http://bit.ly/2wgkDvS"
+"Before changing innodb_log_file_size and/or innodb_log_files_in_group read this: https://bit.ly/2TcGgtU"
         );
     }
     else {


### PR DESCRIPTION
Fix defect link to the mysql documentation. Choose to set the link to version 8 as in Issue major#408 mention.
Links to: https://dev.mysql.com/doc/refman/8.0/en/innodb-redo-log.html