### PR TITLE
README: Clear installation and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,13 @@ All checks done by **MySQLTuner** are documented in [MySQLTuner Internals](https
 Download/Installation
 --
 
-You can download the entire repository by using 'git clone' followed by the cloning URL above. The simplest and shortest method is:
+1) Script direct download (the simplest and shortest method):
 
 	wget http://mysqltuner.pl/ -O mysqltuner.pl
 	wget https://raw.githubusercontent.com/major/MySQLTuner-perl/master/basic_passwords.txt -O basic_passwords.txt
 	wget https://raw.githubusercontent.com/major/MySQLTuner-perl/master/vulnerabilities.csv -O vulnerabilities.csv
-	perl mysqltuner.pl
 
-Of course, you can add the execute bit (`chmod +x mysqltuner.pl`) so you can execute it without calling perl directly.
+2) You can download the entire repository by using `git clone` or `git clone --depth 1 -b master` followed by the cloning URL above.
 
 Optional Sysschema installation for MySQL 5.6
 --
@@ -132,6 +131,8 @@ Specific usage
 __Usage:__ Minimal usage locally
 
 	perl mysqltuner.pl
+
+Of course, you can add the execute bit (`chmod +x mysqltuner.pl`) so you can execute it without calling perl directly.
 
 __Usage:__ Minimal usage remotely
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ All checks done by **MySQLTuner** are documented in [MySQLTuner Internals](https
 Download/Installation
 --
 
+Choose one of these methods:
+
 1) Script direct download (the simplest and shortest method):
 
 	wget http://mysqltuner.pl/ -O mysqltuner.pl


### PR DESCRIPTION
I just discovered that I didn't have to git clone the repository to install the script.

So I checked if it was in the readme and it was there but not 100% clear.