### PR TITLE
Fix syntax error in grant statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ To get information about stored credentials, use the following command:
 
 **Question: What's minimum privileges needed by a specific mysqltuner user in database ?**
 
-        mysql>GRANT SELECT, PROCESS,EXECUTE, REPLICATION CLIENT,SHOW DATABASES,SHOW VIEW ON *.* FOR 'mysqltuner'@'localhost' identified by pwd1234;
+        mysql>GRANT SELECT, PROCESS,EXECUTE, REPLICATION CLIENT,SHOW DATABASES,SHOW VIEW ON *.* TO 'mysqltuner'@'localhost' identified by pwd1234;
 
 **Question: It's not working on my OS! What gives?!**
 


### PR DESCRIPTION
As per [the MySQL docs](https://dev.mysql.com/doc/refman/5.7/en/grant.html), I believe you `GRANT TO` a user, not `GRANT FOR`. Changing this seemed to work for me, at least.

Before:

```
mysql> GRANT SELECT, PROCESS,EXECUTE, REPLICATION CLIENT,SHOW DATABASES,SHOW VIEW ON *.* FOR 'mysqltuner'@'localhost' identified by password;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'FOR 'mysqltuner'@'localhost' identified by password' at line 1
```

After:

```
mysql> GRANT SELECT, PROCESS, EXECUTE, REPLICATION CLIENT,SHOW DATABASES,SHOW VIEW ON *.* TO 'mysqltuner'@'localhost' identified by 'password';
Query OK, 0 rows affected, 1 warning (0.00 sec)
```