### PR TITLE
Add --host to minimal usage locally example

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Specific usage
 
 __Usage:__ Minimal usage locally
 
-	perl mysqltuner.pl
+	perl mysqltuner.pl --host 127.0.0.1
 
 Of course, you can add the execute bit (`chmod +x mysqltuner.pl`) so you can execute it without calling perl directly.
 


### PR DESCRIPTION
After implemented a bunch of suggestions, of which "Configure your accounts with ip or subnets only, then update your configuration with skip-name-resolve=1" and "Restrict Host for user\@% to user\@SpecificDNSorIp" I got a nasty `[!!] Attempted to use login credentials, but they were invalid.` error when trying to use mysqltuner again. Obviously since by default it uses `localhost` (due `mysqladmin`). Add it to the example to show the user the way. :)