### PR TITLE
SCALAR ref while strict refs

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -3247,7 +3247,7 @@ sub mysql_stats {
         } elsif ($myvar{'table_definition_cache'} < $nbtables ) {
             badprint "table_definition_cache(".$myvar{'table_definition_cache'} .") is lower than number of tables($nbtables) ";
             push( @adjvars,
-                "table_definition_cache(".$myvar{'table_definition_cache'} .") > " . $$nbtables . " or -1 (autosizing if supported)" );
+                "table_definition_cache(".$myvar{'table_definition_cache'} .") > " . $nbtables . " or -1 (autosizing if supported)" );
         }
         else {
             goodprint "table_definition_cache(".$myvar{'table_definition_cache'} .") is upper than number of tables($nbtables)";


### PR DESCRIPTION
Hello,
using the script today, I came across the following error: 

```
Can't use string ("620") as a SCALAR ref while "strict refs" in use at
	./mysqltuner.pl line 3249 (#1)
    (F) Only hard references are allowed by "strict refs".  Symbolic
    references are disallowed.  See perlref.
    
Uncaught exception from user code:
	Can't use string ("620") as a SCALAR ref while "strict refs" in use at ./mysqltuner.pl line 3249.
	main::mysql_stats() called at ./mysqltuner.pl line 6377
```
I fixed with the next PR.