### PR TITLE
Include max_allowed_packet in thread memory size

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -2393,6 +2393,7 @@ sub calculations {
           $myvar{'read_rnd_buffer_size'} +
           $myvar{'sort_buffer_size'} +
           $myvar{'thread_stack'} +
+          $myvar{'max_allowed_packet'} +
           $myvar{'join_buffer_size'};
     }
     else {


### PR DESCRIPTION
Each thread can also use max_allowed_packet size, which cloud lead to out of memory in case of lock on a table with many big inserts waiting it.

Fix https://github.com/major/MySQLTuner-perl/issues/378
Fix https://github.com/major/MySQLTuner-perl/issues/456