### PR TITLE
Suggest using mariadb-sys from FromDual in script

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -3577,7 +3577,7 @@ sub mysqsl_pfs {
 "Consider installing Sys schema from https://github.com/mysql/mysql-sys for MySQL"
         ) unless ( mysql_version_le( 5, 6 ) );
         push( @generalrec,
-"Consider installing Sys schema from https://github.com/good-dba/mariadb-sys for MariaDB"
+"Consider installing Sys schema from https://github.com/FromDual/mariadb-sys for MariaDB"
         ) unless ( mysql_version_eq( 10, 0 ) or mysql_version_eq( 5, 5 ) );
 
         return;


### PR DESCRIPTION
Fixes #467 .

This Sys schema has been replaced in README.md in favor of the one from FromDual, so it makes sense to update the script too.