### PR TITLE
Updates link to MyISAM table_cache scalability doc

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -3208,7 +3208,7 @@ sub mysql_stats {
             push( @generalrec,
                     "Read this before increasing "
                   . $table_cache_var
-                  . " over 64: https://bit.ly/1mi7c4C" );
+                  . " over 64: https://bit.ly/2Fulv7r" );
             push( @generalrec,
                     "Read this before increasing for MariaDB"
                   . " https://mariadb.com/kb/en/library/optimizing-table_open_cache/"


### PR DESCRIPTION
Fixes #465 .

The [current bit.ly link](https://bit.ly/1mi7c4C) sends to:
http://www.mysqlperformanceblog.com/2009/11/16/table_cache-negative-scalability/
...which is redirected towards:
https://www.percona.com/blog/?link=2009%2F11%2F16%2Ftable_cache-negative-scalability%2F

It looks like the redirection isn't correct server-side.

The [new bit.ly link](https://bit.ly/2Fulv7r) sends to the correct (final) new URL:
https://www.percona.com/blog/2009/11/16/table_cache-negative-scalability/