### PR TITLE
secure users MariaDB-10.4+ / MySQL auth socket

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1819,7 +1819,7 @@ q{SELECT CONCAT(user, '@', host) FROM mysql.global_priv WHERE
     else {
         @mysqlstatlist = select_array
 "SELECT CONCAT(user, '\@', host) FROM mysql.user WHERE ($PASS_COLUMN_NAME = '' OR $PASS_COLUMN_NAME IS NULL)
-    /*!50501 AND plugin NOT IN ('unix_socket', 'win_socket', 'auth_pam_compat') */
+    /*!50501 AND plugin NOT IN ('auth_socket', 'unix_socket', 'win_socket', 'auth_pam_compat') */
     /*!80000 AND account_locked = 'N' AND password_expired = 'N' */";
     }
     if (@mysqlstatlist) {


### PR DESCRIPTION
To reduce false positives on user accounts that are secure due to being locked or secured with auth_socket, we exclude these from the recommendation.

This is particularly hazardous on MariaDB-10.4 that has mariadb.sys as a locked user without a password for internal purposes.

Versioned comments are used to ensure inappropriate SQL isn't executed on the wrong server version instead of pre-checks.

More details are in commit messages.

Still more changes are coming as from MariaDB-10.4 the mysql.user table is a VIEW not editable with the current recommended direct edits.