### PR TITLE
query_cache off with query_cache_type=OFF OR query_cache_size=0

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -2994,7 +2994,7 @@ sub mysql_stats {
         #return;
     }
     elsif ( $myvar{'query_cache_size'} < 1
-        and $myvar{'query_cache_type'} eq "OFF" )
+        or $myvar{'query_cache_type'} eq "OFF" )
     {
         goodprint
 "Query cache is disabled by default due to mutex contention on multiprocessor machines.";


### PR DESCRIPTION
From the MySQL and MariaDB code (same - 5.5 version):
https://github.com/mysql/mysql-server/blob/5.5/sql/sql_cache.h#L560
https://github.com/MariaDB/server/blob/5.5/sql/sql_cache.h#L572

This is used:
https://github.com/mysql/mysql-server/blob/5.5/sql/sql_prepare.cc#L3058
(same in MariaDB code)

The size=0 and type=0 are both sufficient conditions for the query
cache to be disabled. As such lets consider it ok if its disabled
only in one place. This is the case in mariadb where type=0 (OFF)
is the default as is a non-zero query-cache size.