### PR TITLE
mariadb is using its on name in mariadb/mariadb-admin

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -665,6 +665,9 @@ sub mysql_setup {
     }
     else {
         $mysqladmincmd = which( "mysqladmin", $ENV{'PATH'} );
+        if ( !-e $mysqladmincmd ) {
+            $mysqladmincmd = which( "mariadb-admin", $ENV{'PATH'} );
+	}
     }
     chomp($mysqladmincmd);
     if ( !-e $mysqladmincmd && $opt{mysqladmin} ) {
@@ -673,7 +676,7 @@ sub mysql_setup {
         exit 1;
     }
     elsif ( !-e $mysqladmincmd ) {
-        badprint "Couldn't find mysqladmin in your \$PATH. Is MySQL installed?";
+        badprint "Couldn't find mysqladmin/mariadb-admin in your \$PATH. Is MySQL installed?";
         exit 1;
     }
     if ( $opt{mysqlcmd} ) {
@@ -681,6 +684,9 @@ sub mysql_setup {
     }
     else {
         $mysqlcmd = which( "mysql", $ENV{'PATH'} );
+        if ( !-e $mysqlcmd ) {
+            $mysqlcmd = which( "mariadb", $ENV{'PATH'} );
+	}
     }
     chomp($mysqlcmd);
     if ( !-e $mysqlcmd && $opt{mysqlcmd} ) {
@@ -689,7 +695,7 @@ sub mysql_setup {
         exit 1;
     }
     elsif ( !-e $mysqlcmd ) {
-        badprint "Couldn't find mysql in your \$PATH. Is MySQL installed?";
+        badprint "Couldn't find mysql/mariadb in your \$PATH. Is MySQL installed?";
         exit 1;
     }
     $mysqlcmd =~ s/\n$//g;


### PR DESCRIPTION
The mysql client, mysql, in mariadb is starting to be labeled mariadb.
Likewise mysqladmin is getting called mariadb-admin. Lets check
for these names as well.