### PR TITLE
mariadb gtid mode - base off gtid_current_pos.

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1114,9 +1114,9 @@ sub get_all_vars {
     }
 
     # Support GTID MODE FOR MARIADB
-    # Issue MariaDB GTID mode #272
-    $myvar{'gtid_mode'} = $myvar{'gtid_strict_mode'}
-      if ( defined( $myvar{'gtid_strict_mode'} ) );
+    # Issue MariaDB GTID mode #513
+    $myvar{'gtid_mode'} = 'ON'
+      if ( defined( $myvar{'gtid_current_pos'} ) and $myvar{'gtid_current_pos'} ne '' );
 
     $myvar{'have_threadpool'} = "NO";
     if ( defined( $myvar{'thread_pool_size'} )


### PR DESCRIPTION
gtid_strict_mode isn't sufficient a test for
MariaDB's GTID mode. The gtid_current_pos
however is always non-blank if GTID is enabled.

closes #513