### PR TITLE
travis: test all supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,63 +1,22 @@
-sudo: false
-
 language: perl
+perl:
+  - "5.24"
 
-matrix:
-  include:
-#  - addons:
-#      mariadb: "5.5"
-#    name: "MariaDB 5.5/Perl 5.24"
-#    perl: "5.24"
-#  - addons:
-#      mariadb: "10.0"
-#    name: "MariaDB 10.0/Perl 5.24"
-#    perl: "5.24"
-#  - addons:
-#      mariadb: "10.1"
-#    name: "MariaDB 10.1/Perl 5.24"
-#    perl: "5.24"
-  - addons:
-      mariadb: "10.2"
-    name: "MariaDB 10.2/Perl 5.24"
-    perl: "5.24"
-  - addons:
-      mariadb: "10.5"
-    name: "MariaDB 10.5/Perl 5.24"
-    perl: "5.24"
-    sudo: true
-    env: VERSION=mariadb-10.5
-#  - addons:
-#      mysql: "5.5"
-#    name: "MySQL 5.5/Perl 5.24"
-#    perl: "5.24"
-#  - addons:
-#      mysql: "5.6"
-#    name: "MySQL 5.6/Perl 5.24"
-#    perl: "5.24"
-#  - addons:
-#      apt:
-#        sources:
-#          - mysql-5.7-trusty
-#        packages:
-#          - mysql-server
-#          - mysql-client
-#    name: "MySQL 5.7/Perl 5.24"
-#    perl: "5.24"
-#  - addons:
-#      apt:
-#        sources:
-#          - mysql-8.0-trusty
-#        packages:
-#          - mysql-server
-#          - mysql-client
-#    name: "MySQL 8/Perl 5.24"
-#    perl: "5.24"
+os: linux
+dist: focal
 
-before_install:
-  - git clone git://github.com/haarg/perl-travis-helper
-  - source perl-travis-helper/init
-  - build-perl
-  - perl -V
+services:
+  - docker
+
+env:
+  - DB=mariadb:5.5
+  - DB=mariadb:10.2
+  - DB=mariadb:10.3
+  - DB=mariadb:10.4
+  - DB=mariadb:10.5
+  - DB=mysql:5.5
+  - DB=mysql:5.7
+  - DB=mysql:8.0
 
 install:
   - cpanm --quiet --notest Data::Dumper
@@ -66,12 +25,20 @@ install:
   - cpanm --quiet --notest Text::Template
 
 before_script:
-  # MariaDB-10.4?+ has unix_plugin socket auth, but no password is set.
-  - if [ "$VERSION" == 'mariadb-10.5' ]; then sudo mysql -e 'SET PASSWORD = PASSWORD("")'; fi
-  - echo -e "[client]\nuser=root\npassword=\"\"" > .my.cnf
-  - chmod 600 .my.cnf
+  - mysql --version
+  - mysqladmin --version
+  - docker run -it --name=mysqltestinstance -d -e MYSQL_ALLOW_EMPTY_PASSWORD=yes -p 3306:3306 ${DB}
+  - echo -e "[client]\nuser=root\npassword=\"\"\nhost=127.0.0.1" > ~/.my.cnf
+  - chmod 600 ~/.my.cnf
   - git clone https://github.com/datacharmer/test_db.git
   - cd test_db
+  - count=10
+  - while ! mysql -e 'select version()' && [ $count -gt 0 ]; do echo $count seconds to go; sleep 1; count=$(( $count - 1 )); done
+  - if [ $DB == 'mysql:8.0' ]; then
+      for file in public_key.pem ca.pem server-cert.pem client-key.pem client-cert.pem ; do
+        docker cp mysqltestinstance:/var/lib/mysql/$file "${HOME}" ;
+      done ;
+    fi
   - "cat employees.sql | grep -v 'storage_engine' | mysql"
   - cd ..
 
@@ -79,5 +46,6 @@ script:
   - ./mysqltuner.pl --verbose --tbstat 2>stderr.txt | tee -a "stdout.txt"
 
 after_script:
+  - docker stop mysqltestinstance
   - echo "Standard Output: $(cat stdout.txt)"
   - echo "Standard Error : $(cat stderr.txt)"


### PR DESCRIPTION
Here we use docker to test the upstream supported versions and the MySQLTuner oldest version (5.5).

Turns out the #531 execute permissions are useful for the test.

The travis build looks like https://travis-ci.com/github/grooverdan/MySQLTuner-perl/builds/215009119

Migrating from travis-ci.org to travis-ci.com free account runs all the tests without the delay of several hours to get the results. Might even be able to enable them on pull requests too. The notice on travis-ci.org says migration in a couple of weeks anyway.

To migrate:
https://travis-ci.org/account/repositories as the account holder and top right "Sign up for beta". Adjust travis links in README.md afterwards.

closes #531, #532, #533