### PR TITLE
travis: add percona supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ env:
   - DB=mysql:5.5
   - DB=mysql:5.7
   - DB=mysql:8.0
+  - DB=percona:5.6
+  - DB=percona:5.7
+  - DB=percona:8.0
 
 install:
   - cpanm --quiet --notest Data::Dumper
@@ -34,7 +37,7 @@ before_script:
   - cd test_db
   - count=10
   - while ! mysql -e 'select version()' && [ $count -gt 0 ]; do echo $count seconds to go; sleep 1; count=$(( $count - 1 )); done
-  - if [ $DB == 'mysql:8.0' ]; then
+  - if [[ $DB =~ .*:8.0 ]] ; then
       for file in public_key.pem ca.pem server-cert.pem client-key.pem client-cert.pem ; do
         docker cp mysqltestinstance:/var/lib/mysql/$file "${HOME}" ;
       done ;


### PR DESCRIPTION
Note where Percona announce 3 more years of 5.6 support
https://www.percona.com/blog/2020/12/07/not-ready-to-give-up-mysql-5-6-get-post-eol-support-from-percona/

Note: haven't tested locally. Will need to see how travis handles this. percona images are Centos based until mysql/mariadb which are ubuntu based so there may be some differences, potentially causing failure.