### PR TITLE
Fix `innodb_log_buffer_size` message

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -5985,7 +5985,7 @@ sub mysql_innodb {
           . $mystat{'Innodb_log_writes'}
           . " writes)";
         push( @adjvars,
-                "innodb_log_buffer_size (>= "
+                "innodb_log_buffer_size (> "
               . hr_bytes_rnd( $myvar{'innodb_log_buffer_size'} )
               . ")" );
     }


### PR DESCRIPTION
The operator used to recommend the user to increase the log buffer size (`>=`) is confusing.

Closes #567 (which includes a detailed description).