### PR TITLE
Fix key buffer usage multiple-byte units

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -3514,22 +3514,22 @@ sub mysql_myisam {
     if ( defined( $mycalc{'pct_key_buffer_used'} ) ) {
         if ( $mycalc{'pct_key_buffer_used'} < 90 ) {
             badprint "Key buffer used: $mycalc{'pct_key_buffer_used'}% ("
-              . hr_num( $myvar{'key_buffer_size'} *
-                  $mycalc{'pct_key_buffer_used'} /
-                  100 )
+              . hr_bytes( $myvar{'key_buffer_size'} -
+                  $mystat{'Key_blocks_unused'} *
+                  $myvar{'key_cache_block_size'} )
               . " used / "
-              . hr_num( $myvar{'key_buffer_size'} )
+              . hr_bytes( $myvar{'key_buffer_size'} )
               . " cache)";
 
 #push(@adjvars,"key_buffer_size (\~ ".hr_num( $myvar{'key_buffer_size'} * $mycalc{'pct_key_buffer_used'} / 100).")");
         }
         else {
             goodprint "Key buffer used: $mycalc{'pct_key_buffer_used'}% ("
-              . hr_num( $myvar{'key_buffer_size'} *
-                  $mycalc{'pct_key_buffer_used'} /
-                  100 )
+              . hr_bytes( $myvar{'key_buffer_size'} -
+                  $mystat{'Key_blocks_unused'} *
+                  $myvar{'key_cache_block_size'} )
               . " used / "
-              . hr_num( $myvar{'key_buffer_size'} )
+              . hr_bytes( $myvar{'key_buffer_size'} )
               . " cache)";
         }
     }
@@ -3537,10 +3537,11 @@ sub mysql_myisam {
 
         # No queries have run that would use keys
         debugprint "Key buffer used: $mycalc{'pct_key_buffer_used'}% ("
-          . hr_num(
-            $myvar{'key_buffer_size'} * $mycalc{'pct_key_buffer_used'} / 100 )
+          . hr_bytes( $myvar{'key_buffer_size'} -
+              $mystat{'Key_blocks_unused'} *
+              $myvar{'key_cache_block_size'} )
           . " used / "
-          . hr_num( $myvar{'key_buffer_size'} )
+          . hr_bytes( $myvar{'key_buffer_size'} )
           . " cache)";
     }
 


### PR DESCRIPTION
The "Key buffer used" row showed 131072 bytes as 131K while it should be shown as 128K, so that it matches the multi-byte units key buffer size in the "Key buffer size / total MyISAM indexes" row below.

Furthermore, instead of calculating the used bytes from the previously calculated percentage, doing a round trip which involves rounding errors, calculate the used bytes from the variables directly which does not involve any diversion and hence no possible rounding errors.