### PR TITLE
Do not show thread pool metrics when disabled

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1195,9 +1195,13 @@ sub get_all_vars {
       if ( defined( $myvar{'gtid_current_pos'} )
         and $myvar{'gtid_current_pos'} ne '' );
 
+    # Whether the server uses a thread pool to handle client connections
+    # MariaDB: thread_handling = pool-of-threads
+    # MySQL: thread_handling = loaded-dynamically
     $myvar{'have_threadpool'} = "NO";
-    if ( defined( $myvar{'thread_pool_size'} )
-        and $myvar{'thread_pool_size'} > 0 )
+    if ( defined( $myvar{'thread_handling'} )
+        and ( $myvar{'thread_handling'} eq 'pool-of-threads'
+        || $myvar{'thread_handling'} eq 'loaded-dynamically' ) )
     {
         $myvar{'have_threadpool'} = "YES";
     }
@@ -3316,13 +3320,13 @@ sub mysql_stats {
     }
 
     # Thread cache
-    if ( defined( $myvar{'thread_handling'} )
-        and $myvar{'thread_handling'} eq 'pool-of-threads' )
+    if ( defined( $myvar{'have_threadpool'} )
+        and $myvar{'have_threadpool'} eq 'YES' )
     {
- # https://www.percona.com/doc/percona-server/LATEST/performance/threadpool.html
+ # https://www.percona.com/doc/percona-server/5.7/performance/threadpool.html#status-variables
  # When thread pool is enabled, the value of the thread_cache_size variable
  # is ignored. The Threads_cached status variable contains 0 in this case.
-        infoprint "Thread cache not used with thread_handling=pool-of-threads";
+        infoprint "Thread cache not used with thread pool enabled";
     }
     else {
         if ( $myvar{'thread_cache_size'} eq 0 ) {


### PR DESCRIPTION
Currently thread pool metrics are shown whenever the "thread_pool_size" variable is set. At least on MariaDB this variable is however set even when the thread pool is disabled. This commit changes the check for whether a thread pool is used for client connection handling or not by comparing the "thread_handling" variable value against "pool-of-threads" (MariaDB) or "loaded-dynamically" (MySQL):
- https://mariadb.com/kb/en/thread-pool-system-status-variables/#thread_handling
- https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_thread_handling

The check for whether to show the thread cache metrics is now based on the same derived internal "have_threadpool" variable, effectively skipping thread cache metrics as well on MySQL when the thread pool is not enabled with "thread_handling = loaded-dynamically". The code comment link to Percona about whether the thread cache is used with thread pool enabled has been pinned to v5.7, the latest version which contains the quoted statement. The statement is however still true for MariaDB and MySQL:
- https://mariadb.com/kb/en/server-system-variables/#thread_cache_size