### PR TITLE
Hide recommendation when no key buffer is used

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -3556,7 +3556,7 @@ sub mysql_myisam {
     }
 
     # Key buffer usage
-    if ( defined( $mycalc{'pct_key_buffer_used'} ) ) {
+    if ( $mycalc{'pct_key_buffer_used'} > 0 ) {
         if ( $mycalc{'pct_key_buffer_used'} < 90 ) {
             badprint "Key buffer used: $mycalc{'pct_key_buffer_used'}% ("
               . hr_bytes( $myvar{'key_buffer_size'} -


### PR DESCRIPTION
Currently, when a key_buffer_size=0 is applied, MySQLTuner sets pct_key_buffer_used=0 but still shows it as "[!!]" (bad), recommending to adjust key_buffer_size to "~ 0". The idea surely was show it neither as good or bad in this case, but as debugprint, which is currently never used since pct_key_buffer_used is always defined.

This commit changes the condition to check whether pct_key_buffer_used is larger then zero, to decide whether to show good/bad (with recommendation) or a debug info without recommendation.