### PR TITLE
Remove erroneous dot

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -6667,7 +6667,7 @@ sub close_outputfile {
 sub headerprint {
     prettyprint
       " >>  MySQLTuner $tunerversion\n" 
-      . "\t * Jean-Marie Renouard <jmrenouard\@gmail.com>\n".
+      . "\t * Jean-Marie Renouard <jmrenouard\@gmail.com>\n"
       . "\t * Major Hayden <major\@mhtx.net>\n"
       . " >>  Bug reports, feature requests, and downloads at http://mysqltuner.pl/\n"
       . " >>  Run with '--help' for additional options and output filtering";


### PR DESCRIPTION
With https://github.com/major/MySQLTuner-perl/commit/191b16c21b1a3dd526b1cd367cd2d5568f0dbd51 a syntax error was introduced which I happened to run into. This removes the offending character.