### PR TITLE
Fix MariaDB Sys schema check

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -3922,11 +3922,10 @@ sub mysqsl_pfs {
     unless ( grep /^sys$/, select_array("SHOW DATABASES") ) {
         infoprint "Sys schema is not installed.";
         push( @generalrec,
+          mysql_version_ge( 10, 0 ) ?
+"Consider installing Sys schema from https://github.com/FromDual/mariadb-sys for MariaDB" :
 "Consider installing Sys schema from https://github.com/mysql/mysql-sys for MySQL"
         ) unless ( mysql_version_le( 5, 6 ) );
-        push( @generalrec,
-"Consider installing Sys schema from https://github.com/FromDual/mariadb-sys for MariaDB"
-        ) unless ( mysql_version_ge( 10, 0 ) );
 
         return;
     }


### PR DESCRIPTION
mysqltuner had broken logic - it would always SKIP showing "Sys schema suggestion for MariaDB" (as MariaDB versions are **always** >= `10.0.x` ). 
However quick fix of `unless` to `if` would should **both** mysql and mariadb recommendations, which I think is wrong.

This PR will instead show **only** Mysql recommendation for Mysql versions, and **only** MariaDB recommendation for MariaDB versions.