### PR TITLE
Update mysqltuner.pl

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -6170,7 +6170,7 @@ sub mysql_innodb {
     $mystat{'Innodb_log_waits_computed'} = 0;
 
     if (    defined( $mystat{'Innodb_log_waits'} )
-        and defined( $mystat{'Innodb_log_writes'} ) )
+        and defined( $mystat{'Innodb_log_writes'} ) and $mystat{'Innodb_log_writes'} > 0.000001 )
     {
         $mystat{'Innodb_log_waits_computed'} =
           $mystat{'Innodb_log_waits'} / $mystat{'Innodb_log_writes'};


### PR DESCRIPTION
Innodb Log Writes may be zero right after DB startup.  
In order to prevent division by zero error in line 6175, it is necessary to check whether it is greater than 0. $mystat{'Innodb_log_writes'} > 0.000001