### PR TITLE
Missing return when skipping log file checks

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1431,6 +1431,7 @@ sub get_log_file_real_path {
 sub log_file_recommendations {
     if ( is_remote eq 1 ) {
         infoprint "Skipping error log files checks on remote host";
+        return;
     }
     my $fh;
     $myvar{'log_error'} = $opt{'server-log'}


### PR DESCRIPTION
Related to #661 - message is OK - and other changes to skip checks work as intended, but without a return here, it will look for local log files.