### PR TITLE
Ignore snap filesystem for mountpoint cleanup

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1793,7 +1793,7 @@ sub get_fs_info {
         $v;
     } @iinfo;
     foreach my $info (@iinfo) {
-        next if $info =~ m{(\d+)\t/(run|dev|sys|proc)($|/)};
+        next if $info =~ m{(\d+)\t/(run|dev|sys|proc|snap)($|/)};
         if ( $info =~ /(\d+)\t(.*)/ ) {
             if ( $1 > 85 ) {
                 badprint "mount point $2 is using $1 % of max allowed inodes";


### PR DESCRIPTION
We got the following recommendations: 

```
    Cleanup files from /snap/lxd/22753 mountpoint or reformat your filesystem.	
    Cleanup files from /snap/lxd/24061 mountpoint or reformat your filesystem.
    Cleanup files from /snap/certbot/2913 mountpoint or reformat your filesystem.
    Cleanup files from /snap/certbot/3024 mountpoint or reformat you filesystem.
    Cleanup files from /snap/core20/1974 mountpoint or reformat you filesystem.
    Cleanup files from /snap/core/15511 mountpoint or reformat you filesystem.
    Cleanup files from /snap/core20/2015 mountpoint or reformat you filesystem.
    Cleanup files from /snap/core/15925 mountpoint or reformat you filesystem.
```

The [snap filesystem](https://www.cherryservers.com/blog/a-complete-guide-to-understanding-linux-file-system-tree#snap) should probably be ignored for this recommendation.