### PR TITLE
Only pass `-P` for socket connection when port option is specified

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -811,11 +811,13 @@ sub mysql_setup {
 
     debugprint "MySQL Client: $mysqlcmd";
 
-    $opt{port} = ( $opt{port} eq 0 ) ? 3306 : $opt{port};
-
     # Are we being asked to connect via a socket?
     if ( $opt{socket} ne 0 ) {
-        $remotestring = " -S $opt{socket} -P $opt{port}";
+        if ( $opt{port} ne 0 ) {
+            $remotestring = " -S $opt{socket} -P $opt{port}";
+        } else {
+            $remotestring = " -S $opt{socket}";
+        }
     }
 
     if ( $opt{protocol} ne '' ) {
@@ -825,6 +827,7 @@ sub mysql_setup {
     # Are we being asked to connect to a remote server?
     if ( $opt{host} ne 0 ) {
         chomp( $opt{host} );
+        $opt{port} = ( $opt{port} eq 0 ) ? 3306 : $opt{port};
 
 # If we're doing a remote connection, but forcemem wasn't specified, we need to exit
         if ( $opt{'forcemem'} eq 0 && is_remote eq 1 ) {


### PR DESCRIPTION
This fix implementation of [be1f4b4](https://github.com/major/MySQLTuner-perl/commit/be1f4b48c45aaf759ff0e115a33ee7d4f29cb106) for [GCP cloud-sql-proxy](https://github.com/GoogleCloudPlatform/cloud-sql-proxy). `cloud-sql-proxy` creates multiple sockets on localhost pointing to multiple remote instances with default port.

```
$ curl -L http://mysqltuner.pl/ -o mysqltuner.pl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  254k  100  254k    0     0   524k      0 --:--:-- --:--:-- --:--:--  524k
$ MYSQL_PWD="[REDACTED]" ./mysqltuner.pl --socket=/cloudsql/[REDACTED] --user $USER --skippassword --forcemem 245760 --forceswap 0
 >>  MySQLTuner 2.2.12
	 * Jean-Marie Renouard <jmrenouard@gmail.com>
	 * Major Hayden <major@mhtx.net>
 >>  Bug reports, feature requests, and downloads at http://mysqltuner.pl/
 >>  Run with '--help' for additional options and output filtering

[--] Skipped version check for MySQLTuner script
[!!] Attempted to use login credentials, but they were invalid
exit 1
$ curl -LO https://raw.githubusercontent.com/leonyu/MySQLTuner-perl/master/mysqltuner.pl
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  254k  100  254k    0     0  2973k      0 --:--:-- --:--:-- --:--:-- 2999k
$ MYSQL_PWD="[REDACTED]" ./mysqltuner.pl --socket=/cloudsql/[REDACTED] --user $USER --skippassword --forcemem 245760 --forceswap 0
 >>  MySQLTuner 2.2.12
	 * Jean-Marie Renouard <jmrenouard@gmail.com>
	 * Major Hayden <major@mhtx.net>
 >>  Bug reports, feature requests, and downloads at http://mysqltuner.pl/
 >>  Run with '--help' for additional options and output filtering

[--] Skipped version check for MySQLTuner script
[OK] Logged in using credentials passed on the command line
[--] Assuming 245760 MB of physical memory
[!!] Assuming 0 MB of swap space (use --forceswap to specify)
[OK] Operating on 64-bit architecture

-------- Storage Engine Statistics -----------------------------------------------------------------
...
```