### PR TITLE
Remove innodb_stats_on_metadata mentions in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,16 +171,6 @@ Errors & solutions for performance schema installation
 ERROR at line 21: Failed to open file './tables/sys_config_data_10.sql -- ported', error: 2
 Have a look at #452 solution given by @ericx
 
-Performance tips
---
-
-Metadata statistic updates in MySQL 5.6 and lower can strongly impact performance of database servers.
-Be sure that innodb_stats_on_metadata is disabled.
-
-```bash
-set global innodb_stats_on_metadata = 0;
-```
-
 Fixing sysctl configuration (/etc/sysctl.conf)
 --
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -154,13 +154,6 @@ Sysschema не установлена по умолчанию на MariaDB 10.x.
      ERROR at line 21: Failed to open file './tables/sys_config_data_10.sql -- ported', error: 2
      Посмотрите на #452 решение, данное @ericx
 
-Советы по производительности
---
-Обновление статистики метадаты в версии MySQL 5.6 и ниже могут очень сильно влиять на производительность сервера баз данных и MySQLTuner.
-Убедитесь, что innodb_stats_on_metadata отключен.
-
-    set global innodb_stats_on_metadata = 0;
-
 Примеры использования
 --
 


### PR DESCRIPTION
That flag is off by default, starting with MySQL 5.7, and the tool itself reports it in the "Performance Metrics" section.

Finishes what was started in #709.