### PR TITLE
fix perl shebang

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1,4 +1,4 @@
-#!/bin/env perl
+#!/usr/bin/perl
 # mysqltuner.pl - Version 2.5.2
 # High Performance MySQL Tuning Script
 # Copyright (C) 2015-2023 Jean-Marie Renouard - jmrenouard@gmail.com


### PR DESCRIPTION
Previously at least on Debian it broke with:
$ ./mysqltuner.pl
-bash: ./mysqltuner.pl: /bin/env: bad interpreter: No such file or directory