### PR TITLE
Fix wrong physical memory

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -595,7 +595,6 @@ sub os_setup {
     chomp($physical_memory);
     chomp($swap_memory);
     chomp($os);
-    $physical_memory=$opt{forcemem} if (defined($opt{forcemem}) and $opt{forcemem} gt 0);
     $result{'OS'}{'OS Type'}                   = $os;
     $result{'OS'}{'Physical Memory'}{'bytes'}  = $physical_memory;
     $result{'OS'}{'Physical Memory'}{'pretty'} = hr_bytes($physical_memory);


### PR DESCRIPTION
Closes #779 

The variable `$physical_memory` is correctly assigned from `forcemem` and converted to bytes early in `sub os_setup` (line 523).
``` perl
$physical_memory = $opt{'forcemem'} * 1048576;
```

But then on line 598 it is reassigned (overwritten) from a `forcemem` value, if existing, without converting it to bytes.
``` perl
$physical_memory=$opt{forcemem} if (defined($opt{forcemem}) and $opt{forcemem} gt 0);
```

This leads to a problem when converted/rounded back to KB, MB or GB in `hr_bytes`. Now because of the reassignment `$physical_memory` has the MB value, but `hr_bytes` treats that value as bytes.
``` perl
$result{'OS'}{'Physical Memory'}{'pretty'} = hr_bytes($physical_memory);
```

This will lead to incorrectly determining the Physical memory. For example if a user passes `--forcemem 2000`, the `hr_bytes` will convert that to 2.0K, thinking 2000 is bytes, and the result in the console will be:
```
[--] Physical Memory: 2.0K
```

And ultimately because of this, `mysqltuner` will give wrong suggestions about the memory consumption:
```
*** MySQL's maximum memory usage is dangerously high ***
*** Add RAM before increasing MySQL buffer variables ***
```