### PR TITLE
Improve regexes for log-file error and warning counts (fixed #797)

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -1590,12 +1590,9 @@ sub log_file_recommendations {
     while ( my $logLi = <$fh> ) {
         chomp $logLi;
         $numLi++;
-        debugprint "$numLi: $logLi"
-          if $logLi =~ /warning|error/i and $logLi !~ /Logging to/;
-        $nbErrLog++
-          if $logLi  =~ /error/i
-          and $logLi !~ /(Logging to|\[Warning\].*ERROR_FOR_DIVISION_BY_ZERO)/;
-        $nbWarnLog++ if $logLi =~ /warning/i;
+        debugprint "$numLi: $logLi" if $logLi =~ /\[(warning|error)\]/i;
+        $nbErrLog++  if $logLi =~ /\[error\]/i;
+        $nbWarnLog++ if $logLi =~ /\[warning\]/i;
         push @lastShutdowns, $logLi
           if $logLi =~ /Shutdown complete/ and $logLi !~ /Innodb/i;
         push @lastStarts, $logLi if $logLi =~ /ready for connections/;


### PR DESCRIPTION
Match lines from the log file that have `[ERROR]` or `[Warning]` in them.

Including the square brackets in the regexes also simplifies other tests e.g. a Note that refers to the 'error log'.

NB The regexes could be further improved by removing the case-insensitive flag _if_ the lines in the log file have always used the same capitalisation for 'ERROR' and 'Warning'.
I have looked at the MariaDB source-code for evidence of this, but as yet not found the truth.