### PR TITLE
--forcemem was being applied twice, the second time in bytes

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -608,8 +608,6 @@ sub os_setup {
     chomp($physical_memory);
     chomp($swap_memory);
     chomp($os);
-    $physical_memory = $opt{forcemem}
-      if ( defined( $opt{forcemem} ) and $opt{forcemem} gt 0 );
     $result{'OS'}{'OS Type'}                   = $os;
     $result{'OS'}{'Physical Memory'}{'bytes'}  = $physical_memory;
     $result{'OS'}{'Physical Memory'}{'pretty'} = hr_bytes($physical_memory);


### PR DESCRIPTION
`--forcemem` is already applied in https://github.com/major/MySQLTuner-perl/blob/master/mysqltuner.pl#L536-L545, converting MB to bytes.

This second time was overwriting the first, setting it incorrectly in bytes.