### PR TITLE
Fix division by zero error with MariaDB 10.8.0+ #830

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -6710,7 +6710,10 @@ sub mysql_innodb {
     }
 
     # InnoDB Used Buffer Pool Size vs CHUNK size
-    if (   !defined( $myvar{'innodb_buffer_pool_chunk_size'} )
+    if ( $myvar{'version'} =~ /MariaDB/i and mysql_version_ge(10, 8) and $myvar{'innodb_buffer_pool_chunk_size'} == 0) {
+        infoprint "innodb_buffer_pool_chunk_size is set to 'autosize' (0) in MariaDB >= 10.8. Skipping chunk size checks.";
+    }
+    elsif (   !defined( $myvar{'innodb_buffer_pool_chunk_size'} )
         || $myvar{'innodb_buffer_pool_chunk_size'} == 0
         || !defined( $myvar{'innodb_buffer_pool_size'} )
         || $myvar{'innodb_buffer_pool_size'} == 0


### PR DESCRIPTION
Division by Zero Error w/ MariaDB #830
