### PR TITLE
update endoflife releases

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -2561,14 +2561,12 @@ sub validate_mysql_version {
 
     prettyprint " ";
 
-    if (   mysql_version_eq( 9, 1 )
+    if (   mysql_version_eq( 8,  0 )
         or mysql_version_eq( 8,  4 )
-        or mysql_version_eq( 8,  0 )
-        or mysql_version_eq( 10, 5 )
+        or mysql_version_eq( 9,  4 )
         or mysql_version_eq( 10, 6 )
         or mysql_version_eq( 10, 11 )
         or mysql_version_eq( 11, 4 )
-        or mysql_version_eq( 11, 6 )
         or mysql_version_eq( 11, 8 ) )
     {
         goodprint "Currently running supported MySQL version "


### PR DESCRIPTION
Note that endoflife.software domain certificate expired on 2025-10-04, use the same used for mariadb.