### PR TITLE
Restore compatibility with older Perl versions

### DIFF
--- a/mysqltuner.pl
+++ b/mysqltuner.pl
@@ -5406,7 +5406,8 @@ sub mysql_myisam {
             )
           )
         {
-            my $myisam_table_escape = $myisam_table =~ s/\|/\`/gr;
+            my $myisam_table_escape = $myisam_table;
+            $myisam_table_escape =~ s/\|/\`/g;
             $sql_mig =
 "${sql_mig}-- InnoDB migration for $myisam_table_escape\nALTER TABLE $myisam_table_escape ENGINE=InnoDB;\n\n";
             infoprint
@@ -9676,7 +9677,11 @@ sub which {
     my $prog_name   = shift;
     my $path_string = shift;
     my @path_array  = split /:/, $ENV{'PATH'};
-    if ($is_win) { @path_array = split /;/, $ENV{'PATH'} =~ s/\\/\//gr; }
+    if ($is_win) {
+        my $path_env = $ENV{'PATH'};
+        $path_env =~ s/\\/\//g;
+        @path_array = split /;/, $path_env;
+    }
 
     for my $path (@path_array) {
         if ($is_win) {


### PR DESCRIPTION
The README.md indicates that the project supports Perl 5.6+, but the `r` modifier is used on two regular expressions; this modifier was not added until Perl 5.14, so the script fails on older versions of Perl.

Testing on Perl 5.10, for example:
```
Bareword found where operator expected at mysqltuner.pl line 5409, near "s/\|/\`/gr"
syntax error at mysqltuner.pl line 5409, near "s/\|/\`/gr"
```

The `r` modifier for the regex is simply a shortcut that allows for a one-liner in the code, but it is not necessary for the script to function (and in fact, is only used in 2 places in the script).

This pull request removes the `r` modifier and restores the replacement logic to 2 lines as opposed to the one-liner syntax that is only supported on Perl 5.14+.

By merging this patch, the latest version of MySQLTuner will function on older versions of Perl again. This bug was introduced in commits 9db65eb2c69eb1446ebf923cb2acc0ed299ba883 and 79522b26da489cb63e2226a4c12ee24b19c0e7be