### PR TITLE
Fix regression in Dockerfile entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY ./basic_passwords.txt /basic_passwords.txt
 COPY ./vulnerabilities.csv /vulnerabilities.txt
 
 ENTRYPOINT [ "perl", "/mysqltuner.pl", "--passwordfile", "/basic_passwords.txt",\
-  "--nosysstat", "--defaults-file", "--cvefile", "/vulnerabilities.txt", \
-  "/defaults.cnf", "--dumpdir", "/results", "--outputfile", \
+  "--nosysstat", "--defaults-file", "/defaults.cnf", "--cvefile", "/vulnerabilities.txt", \
+  "--dumpdir", "/results", "--outputfile", \
   "/results/mysqltuner.txt", \
   "--reportfile", "/results/mysqltuner.html" , "--verbose" ]


### PR DESCRIPTION
Seems a regression since version 2.8.x.

Parameter Value  `"/defaults.cnf"` must be specified after parameter key `"--defaults-file"`.